### PR TITLE
#part 36: Handing path to String.split ~on:':'

### DIFF
--- a/code/variables-and-functions/main.topscript
+++ b/code/variables-and-functions/main.topscript
@@ -131,7 +131,7 @@ List.iter ~f:print_endline;;
 #part 36
 let (^>) x f = f x;;
 Sys.getenv_exn "PATH"
-  ^> String.split ~on:':' path
+  ^> String.split ~on:':'
   ^> List.dedup ~compare:String.compare
   ^> List.iter ~f:print_endline
   ;;


### PR DESCRIPTION
This example has more errors than intended.  The right-associativity of **^>** (and the incipient type error is intentional), but I don't think the application of path to String.split ~on:':' is.

If the example is converted to use the left-associative

``` ocaml
Sys.getenv_exn "PATH"
 |> String.split ~on:':' path
 |> List.dedup ~compare:String.compare
 |> List.iter ~f:print_endline
;;
```

Then you get a type error instead of the expected output:

```
Error: This function has type string -> on:char -> string list                                               It is applied to too many arguments; maybe you forgot a `;'. 
```

The pathological thing is that the type error for both cases (with and without the erroneous **path** parameter to **String.split ~on:':'**) of the right-associative **^>** is the same which masks the other type error lying earlier in the right-associative path.

Book is great so far.  It is interesting to see another angle on FP coming from Erlang and Haskell.
