### PR TITLE
fixed recursion on non-directory-entries (FIFO, Dev, ..)

### DIFF
--- a/code/lists-and-patterns/main.topscript
+++ b/code/lists-and-patterns/main.topscript
@@ -173,20 +173,20 @@ List.append [1;2;3] [4;5;6];;
 List.concat [[1;2];[3;4;5];[6];[]];;
 #part 35
 let rec ls_rec s =
-    if Sys.is_file_exn ~follow_symlinks:true s
-    then [s]
-    else
-      Sys.ls_dir s
+    if Sys.is_directory_exn ~follow_symlinks:true s
+    then Sys.ls_dir s
       |> List.map ~f:(fun sub -> ls_rec (s ^/ sub))
       |> List.concat
+    else
+      [s]
   ;;
 #part 36
 let rec ls_rec s =
-    if Sys.is_file_exn ~follow_symlinks:true s
-    then [s]
-    else
-      Sys.ls_dir s
+    if Sys.is_directory_exn ~follow_symlinks:true s
+    then Sys.ls_dir s
       |> List.concat_map ~f:(fun sub -> ls_rec (s ^/ sub))
+    else
+      [s]
   ;;
 #part 37
 let rec length = function


### PR DESCRIPTION
current implementation also does recursion on FIFOs and device files:

```
# ls_rec ".";;
Exception: (Sys_error "./fifo: Not a directory").
```
