### PR TITLE
front-end/doc.ml: fix typo in comment

### DIFF
--- a/code/front-end/doc.ml
+++ b/code/front-end/doc.ml
@@ -6,7 +6,7 @@ exception My_exception of (int -> int) * int
 
 (** Comment for type [weather]  *)
 type weather =
-  | Rain of int (** The comment for construtor Rain *)
+  | Rain of int (** The comment for constructor Rain *)
   | Sun         (** The comment for constructor Sun *)
 
 (** Find the current weather for a country


### PR DESCRIPTION
Trivial typo fix. It’s on page 427 of the book.
