### PR TITLE
Use Time.Zone module instead of Zone

### DIFF
--- a/code/imperative-programming/time_converter.ml
+++ b/code/imperative-programming/time_converter.ml
@@ -6,10 +6,10 @@ let () =
   match In_channel.input_line stdin with
   | None -> failwith "No timezone provided"
   | Some zone_string ->
-    let zone = Zone.find_exn zone_string in
+    let zone = Time.Zone.find_exn zone_string in
     let time_string = Time.to_string_abs (Time.now ()) ~zone in
     Out_channel.output_string stdout
       (String.concat
-         ["The time in ";Zone.to_string zone;" is ";time_string;".\n"]);
+         ["The time in ";Time.Zone.to_string zone;" is ";time_string;".\n"]);
     Out_channel.flush stdout
 


### PR DESCRIPTION
Zone was removed from Core.Std since version 109.42.00
