### PR TITLE
Extra argument of `path` for `String.split_on` was confusing

### DIFF
--- a/code/variables-and-functions/main.topscript
+++ b/code/variables-and-functions/main.topscript
@@ -131,7 +131,7 @@ List.iter ~f:print_endline;;
 #part 36
 let (^>) x f = f x;;
 Sys.getenv_exn "PATH"
-  ^> String.split ~on:':' path
+  ^> String.split ~on:':'
   ^> List.dedup ~compare:String.compare
   ^> List.iter ~f:print_endline
   ;;


### PR DESCRIPTION
If you take the `^>` operated code and swap for `|>` it still
fails, since that argument `path` isn't needed, coming instead from
the call to `Sys.getenv_exn "PATH"`. This confused me as I was
comparing the two examples.

Or maybe don't use the Sys call at all in the second one, for clarity?

I'm just learning (hence reading the book) so I could be totally wrong, and would be happy to learn how/why.
