### PR TITLE
pass Core.Zone.local to Time.to_sec_string in log_entry

### DIFF
--- a/code/guided-tour/main.topscript
+++ b/code/guided-tour/main.topscript
@@ -147,7 +147,7 @@ let log_entry maybe_time message =
       | Some x -> x
       | None -> Time.now ()
     in
-    Time.to_sec_string time ^ " -- " ^ message
+    Time.to_sec_string ~zone:Core.Zone.local (time) ^ " -- " ^ message
   ;;
 log_entry (Some Time.epoch) "A long long time ago";;
 log_entry None "Up to the minute";;


### PR DESCRIPTION
I received 

``` ocaml
Error: This expression has type zone:Core.Zone.t -> bytes                                        
       but an expression was expected of type bytes  
```

When entering the `log_entry` definition into `utop`.  After some discussion in the #ocaml freenode room, this fixes the issue.
