### PR TITLE
Fix quoting of special $@ parameter

### DIFF
--- a/code/corebuild
+++ b/code/corebuild
@@ -13,4 +13,4 @@ ocamlbuild \
     -cflags "-w @A-4-33-41-42-43-34-44" \
     -cflags -strict-sequence \
     -cflags -principal \
-    $@
+    "$@"


### PR DESCRIPTION
A plain $@ parameter expands to:

$1 $2 $3 ...

which may split arguments that contain spaces. Better use "$@" which expands to

"$1" "$2" "$3" ...

and thus escapes each argument correctly and yet indivdually.
