### PR TITLE
Fix Time.to_sec_string example

### DIFF
--- a/code/guided-tour/main.topscript
+++ b/code/guided-tour/main.topscript
@@ -147,7 +147,7 @@ let log_entry maybe_time message =
       | Some x -> x
       | None -> Time.now ()
     in
-    Time.to_sec_string time Time.Zone.local ^ " -- " ^ message
+    Time.to_sec_string time ~zone:Time.Zone.utc ^ " -- " ^ message
   ;;
 log_entry (Some Time.epoch) "A long long time ago";;
 log_entry None "Up to the minute";;

--- a/code/guided-tour/main.topscript
+++ b/code/guided-tour/main.topscript
@@ -147,7 +147,7 @@ let log_entry maybe_time message =
       | Some x -> x
       | None -> Time.now ()
     in
-    Time.to_sec_string time ^ " -- " ^ message
+    Time.to_sec_string time Time.Zone.local ^ " -- " ^ message
   ;;
 log_entry (Some Time.epoch) "A long long time ago";;
 log_entry None "Up to the minute";;


### PR DESCRIPTION
As of Core [version 112.17.00](https://github.com/janestreet/core/commit/5ee4c65df85e5720dbbcc14087e2ef28259930ab) Time.to_sec_string requires a time zone.
