### PR TITLE
Fix several signature mismatches

### DIFF
--- a/code/classes/class_types_stack.ml
+++ b/code/classes/class_types_stack.ml
@@ -12,7 +12,7 @@ end
 module AbstractStack : sig
    type 'a t = < pop: 'a option; push: 'a -> unit >
 
-   val make : unit -> 'a t
+   val make : 'a list -> 'a t
 end = Stack
 
 (* part 2 *)
@@ -20,11 +20,11 @@ module VisibleStack : sig
   
   type 'a t = < pop: 'a option; push: 'a -> unit >
 
-  class ['a] stack : object
+  class ['a] stack : 'a list -> object
     val mutable v : 'a list
     method pop : 'a option
     method push : 'a -> unit
   end
 
-  val make : unit -> 'a t
+  val make : 'a list -> 'a t
 end = Stack


### PR DESCRIPTION
Especially, the following errata seems not trivial to me.

CURRENT
  class ['a] stack : object

THIS PR
  class ['a] stack : 'a list -> object
